### PR TITLE
Allow configuring of default folder and filetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,4 +147,43 @@ Additional files to move to the asset directory.
     },
   ];
 }
+
+### directories
+
+Default: `["static", "icons", "page-data"]`
+
+The directories to move to the asset directory.
+
+```javascript
+// Your gatsby-config.js
+{
+  plugins: [
+    {
+      resolve: "gatsby-plugin-asset-path",
+      options: {
+        directories: ["static"],
+      },
+    },
+  ];
+}
+```
+
+### fileTypes
+
+Default: `["js", "css"]`
+
+The types of files in the root publicFolder to move to the asset directory.
+
+```javascript
+// Your gatsby-config.js
+{
+  plugins: [
+    {
+      resolve: "gatsby-plugin-asset-path",
+      options: {
+        directories: ['js', 'map', 'css'],
+      },
+    },
+  ];
+}
 ```

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -23,7 +23,14 @@ export const onCreateWebpackConfig = (
  * Moves all js and css files into timestamp-named folder
  * @see {@link https://next.gatsbyjs.org/docs/node-apis/#onPostBuild}
  */
-export const onPostBuild = async ({ pathPrefix }, { additionalFiles = [] }) => {
+export const onPostBuild = async (
+  { pathPrefix },
+  {
+    additionalFiles = [],
+    directories = ["static", "icons", "page-data"],
+    fileTypes = ["js", "css"],
+  },
+) => {
   const publicFolder = "./public";
   const assetFolder = path.join(publicFolder, `.${pathPrefix}`);
 
@@ -33,11 +40,12 @@ export const onPostBuild = async ({ pathPrefix }, { additionalFiles = [] }) => {
     return fs.move(currentPath, newPath);
   };
 
+  const filesExtensions = fileTypes.join("|");
+  const filesRegex = RegExp(`.*.(${filesExtensions})$`);
   const filterFilesIn = (folder) =>
-    fs.readdirSync(folder).filter((file) => /.*\.(js|css)$/.test(file));
+    fs.readdirSync(folder).filter((file) => filesRegex.test(file));
 
   const filesInPublicFolder = filterFilesIn(publicFolder);
-  const directories = ["static", "icons", "page-data"];
   const thingsToMove = directories
     .concat(filesInPublicFolder)
     .concat(additionalFiles);


### PR DESCRIPTION
- Added `directories` setting to override which folders to move
- Added `fileTypes` setting to specify which file types in the public folder to move, currently only moves `css` and `js` files.

Currently the plugin throws an error if an `icon` folder doesn't exist.
Also needed the map files moving along with the js files as they were still in the root after the js files were moved.